### PR TITLE
Handle NVAPI_GPU_NOT_POWERED

### DIFF
--- a/DellFanManagementApp/TemperatureReaders/NvidiaGpuTemperatureReader.cs
+++ b/DellFanManagementApp/TemperatureReaders/NvidiaGpuTemperatureReader.cs
@@ -21,10 +21,11 @@ namespace DellFanManagement.App.TemperatureReaders
 
             foreach (PhysicalGPU gpu in PhysicalGPU.GetPhysicalGPUs())
             {
-                string name = gpu.FullName.Replace(" Laptop GPU", string.Empty);
-
+                string name = null;
                 try
                 {
+                    name = gpu.FullName.Replace(" Laptop GPU", string.Empty);
+
                     foreach (GPUThermalSensor sensor in gpu.ThermalInformation.ThermalSensors)
                     {
                         temperatures.Add(name, sensor.CurrentTemperature);
@@ -34,8 +35,11 @@ namespace DellFanManagement.App.TemperatureReaders
                 {
                     if (exception.Message == "NVAPI_GPU_NOT_POWERED")
                     {
-                        // GPU is currently powered off.
-                        temperatures.Add(name, 0);
+                        if (name != null)
+                        {
+                            // GPU is currently powered off.
+                            temperatures.Add(name, 0);
+                        }
                     }
                     else if (exception.Message == "NVAPI_NVIDIA_DEVICE_NOT_FOUND")
                     {


### PR DESCRIPTION
Hey just a quick bugfix - I was getting a NVAPI_GPU_NOT_POWERED exception getting thrown at `gpu.FullName` which was causing the background thread to die I think. So I moved that line of code into the try-catch 

```
string name = gpu.FullName.Replace(" Laptop GPU", string.Empty);
```

Dell XPS 9570
BIOS 1.22.1 12/10/2021

Btw big kudos @AaronKelley for publishing this repo! I have my own fork where I added a quick access tray app :) Feel free to get inspiration for yours 😀 https://github.com/navhaxs/DellFanManagement